### PR TITLE
Fix file deletion on W-03 cards

### DIFF
--- a/FlashAirSync.php
+++ b/FlashAirSync.php
@@ -102,7 +102,8 @@ UPLOAD=1
     {
       // Delete from card
       echo "Delete {$From}\n";
-      command("upload.cgi", array('DEL' => $From));
+      echo command("upload.cgi", array('DEL' => $From));
+      echo "\n";
       unlink(dirname($To) . '/.Manifest/'.basename($To));
     }
     elseif(!file_exists($To))
@@ -154,7 +155,7 @@ UPLOAD=1
       exit;
     }
 
-    $Command = is_numeric($Op) ? "http://{$FlashAirIP}/command.cgi?op=$Op" : "http://{$FlashAirIP}/{$Op}?__DUMMY__=1";
+    $Command = is_numeric($Op) ? "http://{$FlashAirIP}/command.cgi?op=$Op" : "http://{$FlashAirIP}/{$Op}?";
 
     foreach($Args as $k => $v)
     {


### PR DESCRIPTION
My card is a 8GB W-03 (`VERSION=FA9CAW3AW3.00.00`).

Without this fix, deleting a file locally would attempt to delete it from a card, without success, then it would copy the file back from the card. It looks like the newer firmware doesn't like the `__DUMMY__` parameter.

Luckily, the `?&` combination is accepted, so the fix was easy.

Additionally, this PR outputs the result of the deletion command (SUCCESS or NG), for easier troubleshooting.
